### PR TITLE
Version 1.0.1 fixes output bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 
 .idea/
+nupkg
 
 # User-specific files
 *.rsuser

--- a/src/Ui/Ui.ConsoleApp/Helpers/CoreLogic.cs
+++ b/src/Ui/Ui.ConsoleApp/Helpers/CoreLogic.cs
@@ -4,7 +4,9 @@
 
 	using Models.Result;
 
-	/// <summary>
+    using Spectre.Console;
+
+    /// <summary>
 	/// Provides core logic methods.
 	/// </summary>
 	public static class CoreLogic
@@ -65,7 +67,7 @@
 					var name = match.Groups[1]
 						.Value;
 					var version = match.Groups[2]
-						.Value;
+						.Value.EscapeMarkup();
 					if (!result.ContainsKey(name))
 					{
 						result.Add(name, version);

--- a/src/Ui/Ui.ConsoleApp/Properties/launchSettings.json
+++ b/src/Ui/Ui.ConsoleApp/Properties/launchSettings.json
@@ -3,7 +3,7 @@
   "profiles": {
     "LocalDebug": {
       "commandName": "Project",
-      "commandLineArgs": "execute D:\\repos\\Heurich\\Laker",
+      "commandLineArgs": "simulate .",
       "environmentVariables": {
       }
     }

--- a/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
+++ b/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
@@ -6,19 +6,22 @@
 		<RootNamespace>devdeer.tools.tocpm</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<Version>1.0.0-beta</Version>
+		<Version>1.0.1</Version>
 		<PackageId>devdeer.tools.tocpm</PackageId>
 		<Title>Nuget CPM converter</Title>
 		<Authors>DEVDEER GmbH</Authors>
 		<Description>This dotnet tool reads all csproj-files under a given folder and converts them to use the Nuget CPM instead of implicit versionning inside the csproj.  </Description>
-		<Copyright>2022 DEVDEER GmbH</Copyright>
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+		<Copyright>2023 DEVDEER GmbH</Copyright>
 		<PackageProjectUrl>https://github.com/DEVDEER/dotnet-tocpm</PackageProjectUrl>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<RepositoryUrl>https://github.com/DEVDEER/dotnet-tocpm</RepositoryUrl>
 		<RepositoryType>Github</RepositoryType>
 		<PackageTags>dotnet,tool,nuget,CPM</PackageTags>
 		<PackageReleaseNotes>
-			- Fixed Regex for package references causing a bug where items where not found if no blank character was before the final slash.
+            - Going out of beta with this version.
+			- When outputting the project structure "[" and "]" will be escaped (see https://github.com/DEVDEER/dotnet-tocpm/issues/5).
+            - Nuget updates
 		</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageIcon>icon.png</PackageIcon>
@@ -34,10 +37,10 @@
 			<Pack>True</Pack>
 			<PackagePath></PackagePath>
 		</None>
-		<None Include="readme.md" Pack="true" PackagePath="\"/>
+		<None Include="readme.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Spectre.Console" Version="0.45.0" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+		<PackageReference Include="Spectre.Console" Version="0.46.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.46.0" />
 	</ItemGroup>
 </Project>

--- a/src/Ui/Ui.ConsoleApp/readme.md
+++ b/src/Ui/Ui.ConsoleApp/readme.md
@@ -15,7 +15,7 @@ The tool requires the .NET 7 runtime (or SDK) installed on the machine.
 Use the following command to install `dotnet-tocpm`:
 
 ```shell
-dotnet tool install -g --prerelease devdeer.tools.tocpm
+dotnet tool install -g devdeer.tools.tocpm
 ```
 
 After this command ran you can check the success by running:
@@ -28,7 +28,7 @@ This should result in an output like this:
 
 ```shell
 tocpm -v
-0.0.1-alpha
+1.0.1
 ```
 
 ## Usage


### PR DESCRIPTION
This fixes #5 by escaping the version part before it gets outputted. This PR also updates the Nuget references.