### PR TITLE
Fixed issue with characters breaking the Spectre markup on output.

### DIFF
--- a/src/Ui/Ui.ConsoleApp/Commands/BaseCommand.cs
+++ b/src/Ui/Ui.ConsoleApp/Commands/BaseCommand.cs
@@ -64,7 +64,7 @@
                         result = CoreLogic.GetPackagePropContent(packages);
                         if (OnlySimulate)
                         {
-                            markupResult = MarkupHelper.AddConsoleMarkup(result);
+                            markupResult = MarkupHelper.AddConsoleMarkup(Markup.Escape(result));
                             success = true;
                         }
                     });

--- a/src/Ui/Ui.ConsoleApp/Helpers/OutputHelper.cs
+++ b/src/Ui/Ui.ConsoleApp/Helpers/OutputHelper.cs
@@ -23,7 +23,8 @@
             table.AddColumn(new TableColumn("Version"));
             foreach (var package in packages.Keys.OrderBy(k => k))
             {
-                table.AddRow(package, packages[package].Version);
+                var version = Markup.Escape(packages[package].Version);
+                table.AddRow(package, version);
             }
             AnsiConsole.Write(table);
         }

--- a/src/Ui/Ui.ConsoleApp/Properties/launchSettings.json
+++ b/src/Ui/Ui.ConsoleApp/Properties/launchSettings.json
@@ -3,7 +3,7 @@
   "profiles": {
     "LocalDebug": {
       "commandName": "Project",
-      "commandLineArgs": "execute e:\\coding\\KhanTest",
+      "commandLineArgs": "simulate e:\\repos\\BMA\\oak",
       "environmentVariables": {
       }
     }

--- a/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
+++ b/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
@@ -6,7 +6,7 @@
 		<RootNamespace>devdeer.tools.tocpm</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-        <Version>1.1.1</Version>
+        <Version>1.2.0</Version>
 		<PackageId>devdeer.tools.tocpm</PackageId>
 		<Title>Nuget CPM converter</Title>
 		<Authors>DEVDEER GmbH</Authors>
@@ -19,9 +19,7 @@
 		<RepositoryType>Github</RepositoryType>
 		<PackageTags>dotnet,tool,nuget,CPM</PackageTags>
 		<PackageReleaseNotes>
-            - Complete redesign of version identification to fix bugs with packages with more than 1 line and additional attributes lost in packages.
-            - Upgraded to .NET 8.
-            - Package upgrades of Spectre Console.
+            - Fixed issue with characters breaking the Spectre markup on output.
 		</PackageReleaseNotes>
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
The tool will not crash if characters from the csproj-files are conflicting with Spectre console markup. The lines where secured by using `Markup.Encode`.