### PR TITLE
fix documentation: use 'execute' instead of 'run'

### DIFF
--- a/src/Ui/Ui.ConsoleApp/Program.cs
+++ b/src/Ui/Ui.ConsoleApp/Program.cs
@@ -16,8 +16,8 @@ app.Configure(
             .WithExample("simulate", ".");
         config.AddCommand<ExecuteCommand>("execute")
             .WithDescription("Executes a real run at the specified location.")
-            .WithExample("run", @"C:\temp\project")
-            .WithExample("run", @"C:\temp\project", "-f");
+            .WithExample("execute", @"C:\temp\project")
+            .WithExample("execute", @"C:\temp\project", "-f");
     });
 var result = app.Run(args);
 return result;

--- a/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
+++ b/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
@@ -6,7 +6,7 @@
 		<RootNamespace>devdeer.tools.tocpm</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
 		<PackageId>devdeer.tools.tocpm</PackageId>
 		<Title>Nuget CPM converter</Title>
 		<Authors>DEVDEER GmbH</Authors>

--- a/src/Ui/Ui.ConsoleApp/readme.md
+++ b/src/Ui/Ui.ConsoleApp/readme.md
@@ -42,8 +42,8 @@ USAGE:
 
 EXAMPLES:
     tocpm simulate .
-    tocpm run C:\temp\project
-    tocpm run C:\temp\project -f
+    tocpm execute C:\temp\project
+    tocpm execute C:\temp\project -f
 
 OPTIONS:
     -h, --help       Prints help information
@@ -52,7 +52,6 @@ OPTIONS:
 COMMANDS:
     simulate    Simulates the operation at the provided location and writes the results to the console
     execute     Executes a real run at the specified location
-
 ```
 
 A simple and secure way to test the tool is to perform a dry run. Use the `simulate` command for this by specifying a folder. Lets assume that you've got a solution in the folder `C:\temp\test`. Your command then would be


### PR DESCRIPTION
this patch fixes the usage description: currently it states that 'run' is a valid command. It should be 'execute'.