### PR TITLE
fix: version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The tool requires the .NET 7 runtime (or SDK) installed on the machine.
 Use the following command to install `dotnet-tocpm`:
 
 ```shell
-dotnet tool install -g --prerelease devdeer.tools.tocpm
+dotnet tool install -g devdeer.tools.tocpm
 ```
 
 After this command ran you can check the success by running:
@@ -39,7 +39,7 @@ This should result in an output like this:
 
 ```shell
 tocpm -v
-0.0.1-alpha
+1.3.1
 ```
 
 ## Usage

--- a/src/Ui/Ui.ConsoleApp/Program.cs
+++ b/src/Ui/Ui.ConsoleApp/Program.cs
@@ -1,15 +1,21 @@
-﻿using System.Text;
+﻿using System.Reflection;
+using System.Text;
 
 using devdeer.tools.tocpm.Commands;
 
 using Spectre.Console.Cli;
 
+var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3);
 Console.InputEncoding = Encoding.UTF8;
 Console.OutputEncoding = Encoding.UTF8;
 var app = new CommandApp();
 app.Configure(
     config =>
     {
+        if (!string.IsNullOrEmpty(version))
+        {
+            config.SetApplicationVersion(version);
+        }
         config.SetApplicationName("tocpm");
         config.AddCommand<SimulateCommand>("simulate")
             .WithDescription("Simulates the operation at the provided location and writes the results to the console.")

--- a/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
+++ b/src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj
@@ -6,7 +6,7 @@
 		<RootNamespace>devdeer.tools.tocpm</RootNamespace>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-        <Version>1.3.0</Version>
+        <Version>1.3.1</Version>
 		<PackageId>devdeer.tools.tocpm</PackageId>
 		<Title>Nuget CPM converter</Title>
 		<Authors>DEVDEER GmbH</Authors>


### PR DESCRIPTION
# Problem

Currently the README showcases how to use the `-v` or `--version` command to display the installed version of the tool, but the output is:

```shell
dotnet run --project ./src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj -- -v
Using launch settings from ./src/Ui/Ui.ConsoleApp/Properties/launchSettings.json...

Error: Unexpected option 'v'.

       -v
       ^^ Did you forget the command?
```

# Solution

This PR attempts to bring this command back by explicitly passing the version to the configuration object at startup. The result looks as follows:

```shell
dotnet run --project ./src/Ui/Ui.ConsoleApp/Ui.ConsoleApp.csproj -- --version
Using launch settings from ./src/Ui/Ui.ConsoleApp/Properties/launchSettings.json...
1.3.1
```

# Tradeoff

Dynamically resolving the version at runtime via reflection creates some startup overhead. Measuring this with a stopwatch yields the following diff on my machine:

- before -> 18ms
- now -> 21ms

Other ways to resolve the version at build time rather than at runtime might exist, but to me the overhead seemed not impactful enough to pursue another option.