### PR TITLE
When an exception occurs, display the file location.

### DIFF
--- a/src/Ui/Ui.ConsoleApp/Helpers/CoreLogic.cs
+++ b/src/Ui/Ui.ConsoleApp/Helpers/CoreLogic.cs
@@ -112,7 +112,7 @@
                                 var info = new PackageInformation
                                 {
                                     Name = reader.GetAttribute("Include") ?? throw new ApplicationException(
-                                        "Invalid csproj version reference. Include is missing."),
+                                        $"Invalid csproj version reference. Include is missing. File location: {file.FullName}"),
                                     Version = version,
                                     Xml = reader.ReadOuterXml()
                                 };


### PR DESCRIPTION
`Error: Invalid csproj version reference. Include is missing.`

No indication of which project file configuration has errors.